### PR TITLE
Fix: Return null for missing StringSet keys in SharedPreferences

### DIFF
--- a/internal-core/src/main/java/com/pandulapeter/beagle/core/manager/LocalStorageManager.kt
+++ b/internal-core/src/main/java/com/pandulapeter/beagle/core/manager/LocalStorageManager.kt
@@ -81,7 +81,7 @@ internal class LocalStorageManager(context: Context) {
 
         class StringSet(preferences: SharedPreferences, mainKey: kotlin.String) : SharedPreferencesMap<Set<kotlin.String>?>(preferences, mainKey) {
 
-            override fun getFinal(key: kotlin.String) = preferences.getStringSet(key, null).orEmpty()
+            override fun getFinal(key: kotlin.String): Set<kotlin.String>? = preferences.getStringSet(key, null)
 
             override fun setFinal(key: kotlin.String, value: Set<kotlin.String>?) = preferences.edit().putStringSet(key, value).apply()
         }


### PR DESCRIPTION
## Problem

The `StringSet::getFinal` method returns an empty set (using `orEmpty`) when a key was not found in `SharedPreferences`.

## Solution

To align with the expected behavior of returning `null` when there is **no stored value** for the `key`.
This prevents the `empty set` from incorrectly being treated as the `initial value`, e.g. when we use `MultipleSelectionListModule` with `isValuePersisted = true`.

## Video

https://github.com/user-attachments/assets/f7e05151-557e-46b9-ad17-729f3324b9b9

